### PR TITLE
feat: support BEGIN…END blocks in T-SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS
+
+## T-SQL Formatting
+- `TSqlFormatter.DoDialectConfig` lists tokens considered opening and closing parentheses. Include `BEGIN` and `END` here to ensure blocks indent properly.
+- Tokenizer builds its parentheses regex directly from the dialect configuration; updating the config automatically adjusts token types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+## T-SQL Formatting
+- Add multi-word top-level keywords (e.g., `CREATE PROCEDURE`, `ALTER PROCEDURE`) to `s_reservedTopLevelWords` in `TSqlFormatter` to ensure stored procedure definitions are formatted as standalone statements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - `TSqlFormatter.DoDialectConfig` lists tokens considered opening and closing parentheses. Include `BEGIN` and `END` here to ensure blocks indent properly.
 - Tokenizer builds its parentheses regex directly from the dialect configuration; updating the config automatically adjusts token types.
 - Add multi-word top-level keywords (e.g., `CREATE PROCEDURE`, `ALTER PROCEDURE`) to `s_reservedTopLevelWords` in `TSqlFormatter` to ensure stored procedure definitions are formatted as standalone statements.
+- `TSqlFormatter` tracks `_blockDepth` (parentheses depth) so semicolons inside parentheses don't reset indentation and `SET` behaves as a newline keyword within procedures.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ WHERE
   foo = 'bar'
 ```
 
+T-SQL `BEGIN ... END` blocks are also recognized and indented:
+
+```c#
+SqlFormatter.Of(Dialect.TSql).Format("BEGIN SELECT * FROM tbl END");
+```
+
+```sql
+BEGIN
+  SELECT
+    *
+  FROM
+    tbl
+END
+```
+
 [standard sql]: https://en.wikipedia.org/wiki/SQL:2011
 [couchbase n1ql]: http://www.couchbase.com/n1ql
 [ibm db2]: https://www.ibm.com/analytics/us/en/technology/db2/

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -188,7 +188,9 @@ namespace SQL.Formatter.Test
             var expected = "BEGIN DISTRIBUTED TRAN\nSELECT\n  1";
 
             Assert.Equal(expected, Formatter.Format(sql));
-          
+
+        }
+
         [Fact]
         public void FormatsCreateProcedureDefinition()
         {

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SQL.Formatter.Core;
 using SQL.Formatter.Language;
 using SQL.Formatter.Test.Behavior;
 using SQL.Formatter.Test.Feature;
@@ -145,6 +146,30 @@ namespace SQL.Formatter.Test
                         { "var name1", "'var value1'"},
                         { "var name2", "'var value2'"},
                     }));
+        }
+
+        [Fact]
+        public void TokenizerTreatsBeginEndAsParentheses()
+        {
+            var tokenizer = new TSqlFormatter(FormatConfig.Builder().Build()).Tokenizer();
+            var tokens = tokenizer.Tokenize("BEGIN SELECT 1 END");
+
+            Assert.Equal(TokenTypes.OPEN_PAREN, tokens.Get(0).Type);
+            Assert.Equal(TokenTypes.CLOSE_PAREN, tokens.Get(tokens.Size() - 1).Type);
+        }
+
+        [Fact]
+        public void FormatsNestedBeginEndBlocks()
+        {
+            var sql = "BEGIN BEGIN SELECT 1 END END";
+            var expected = "BEGIN\n" +
+                           "  BEGIN\n" +
+                           "    SELECT\n" +
+                           "      1\n" +
+                           "  END\n" +
+                           "END";
+
+            Assert.Equal(expected, Formatter.Format(sql));
         }
     }
 }

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -171,5 +171,23 @@ namespace SQL.Formatter.Test
 
             Assert.Equal(expected, Formatter.Format(sql));
         }
+
+        [Fact]
+        public void DoesNotTreatBeginTranAsBlock()
+        {
+            var sql = "BEGIN TRAN\nSELECT 1";
+            var expected = "BEGIN TRAN\nSELECT\n  1";
+
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void DoesNotTreatBeginDistributedTranAsBlock()
+        {
+            var sql = "BEGIN DISTRIBUTED TRAN\nSELECT 1";
+            var expected = "BEGIN DISTRIBUTED TRAN\nSELECT\n  1";
+
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
     }
 }

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -146,5 +146,27 @@ namespace SQL.Formatter.Test
                         { "var name2", "'var value2'"},
                     }));
         }
+
+        [Fact]
+        public void FormatsCreateProcedureDefinition()
+        {
+            Assert.Equal(
+                "CREATE PROCEDURE\n"
+                + "  test AS\n"
+                + "SELECT\n"
+                + "  1;",
+                Formatter.Format("CREATE PROCEDURE test AS SELECT 1;"));
+        }
+
+        [Fact]
+        public void FormatsAlterProcedureDefinition()
+        {
+            Assert.Equal(
+                "ALTER PROCEDURE\n"
+                + "  test AS\n"
+                + "SELECT\n"
+                + "  1;",
+                Formatter.Format("ALTER PROCEDURE test AS SELECT 1;"));
+        }
     }
 }

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -213,5 +213,35 @@ namespace SQL.Formatter.Test
                 Formatter.Format("ALTER PROCEDURE test AS SELECT 1;"));
 
         }
+
+        [Fact]
+        public void FormatsProcedureBodyWithSemicolon()
+        {
+            Assert.Equal(
+                "CREATE PROCEDURE\n"
+                + "  test AS BEGIN\n"
+                + "    SET\n"
+                + "      NOCOUNT ON;\n"
+                + "    SELECT\n"
+                + "      1;\n"
+                + "    SELECT\n"
+                + "      2;\n"
+                + "  END;",
+                Formatter.Format("CREATE PROCEDURE test AS BEGIN SET NOCOUNT ON; SELECT 1; SELECT 2; END;"));
+        }
+
+        [Fact]
+        public void KeepsIndentInsideParenthesesWithSemicolon()
+        {
+            var sql = "SELECT (SELECT 1; SELECT 2);";
+            var expected = "SELECT\n"
+                           + "  (\n"
+                           + "    SELECT\n"
+                           + "      1;\n"
+                           + "    SELECT\n"
+                           + "      2\n"
+                           + "  );";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
     }
 }

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -196,8 +196,11 @@ namespace SQL.Formatter.Language
             new List<string>{
                 "ADD",
                 "ALTER COLUMN",
+                // Recognize procedure definition clauses as independent statements
+                "ALTER PROCEDURE",
                 "ALTER TABLE",
                 "CASE",
+                "CREATE PROCEDURE",
                 "DELETE FROM",
                 "END",
                 "EXCEPT",

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -235,6 +235,9 @@ namespace SQL.Formatter.Language
                 "FULL OUTER JOIN",
                 "CROSS JOIN"};
 
+        /// <summary>
+        /// Builds the T-SQL dialect configuration, including BEGIN..END block delimiters.
+        /// </summary>
         public override DialectConfig DoDialectConfig()
         {
             return DialectConfig.Builder()
@@ -249,7 +252,7 @@ namespace SQL.Formatter.Language
                         StringLiteral.SingleQuote,
                         StringLiteral.BackQuote,
                         StringLiteral.Bracket})
-                .OpenParens(new List<string> { "(", "CASE" })
+                .OpenParens(new List<string> { "(", "CASE", "BEGIN" })
                 .CloseParens(new List<string> { ")", "END" })
                 .IndexedPlaceholderTypes(new List<string>())
                 .NamedPlaceholderTypes(new List<string> { "@" })

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -239,9 +239,6 @@ namespace SQL.Formatter.Language
                 "FULL OUTER JOIN",
                 "CROSS JOIN"};
 
-        /// <summary>
-        /// Builds the T-SQL dialect configuration, including BEGIN..END block delimiters.
-        /// </summary>
         public override DialectConfig DoDialectConfig()
         {
             return DialectConfig.Builder()
@@ -269,13 +266,19 @@ namespace SQL.Formatter.Language
                 .Build();
         }
 
+        /// <summary>
+        /// Current parentheses depth. When greater than zero, semicolons terminate statements
+        /// without resetting indentation and <c>SET</c> is treated as a newline keyword.
+        /// </summary>
+        private int _blockDepth;
+
         public TSqlFormatter(FormatConfig cfg) : base(cfg)
         {
         }
 
         protected override Token TokenOverride(Token token)
         {
-            if (token.Type == TokenTypes.OPEN_PAREN && token.Value.Equals("BEGIN", StringComparison.OrdinalIgnoreCase))
+            if (token.Type == TokenTypes.OPEN_PAREN)
             {
                 var next = TokenLookAhead();
                 if (IsTransactionBegin(next))
@@ -287,6 +290,33 @@ namespace SQL.Formatter.Language
             return token;
         }
 
+        protected override string FormatOpeningParentheses(Token token, string query)
+        {
+            var result = base.FormatOpeningParentheses(token, query);
+            _blockDepth++;
+            return result;
+        }
+
+        protected override string FormatClosingParentheses(Token token, string query)
+        {
+            var result = base.FormatClosingParentheses(token, query);
+            if (_blockDepth > 0)
+            {
+                _blockDepth--;
+            }
+
+            return result;
+        }
+
+        protected override string FormatQuerySeparator(Token token, string query)
+        {
+            if (_blockDepth > 0)
+            {
+                return query.TrimEnd() + Show(token) + "\n";
+            }
+
+            return base.FormatQuerySeparator(token, query);
+        }
         private bool IsTransactionBegin(Token next)
         {
             if (next == null)

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SQL.Formatter.Core;
 
 namespace SQL.Formatter.Language
@@ -267,6 +268,49 @@ namespace SQL.Formatter.Language
 
         public TSqlFormatter(FormatConfig cfg) : base(cfg)
         {
+        }
+
+        protected override Token TokenOverride(Token token)
+        {
+            if (token.Type == TokenTypes.OPEN_PAREN && token.Value.Equals("BEGIN", StringComparison.OrdinalIgnoreCase))
+            {
+                var next = TokenLookAhead();
+                if (IsTransactionBegin(next))
+                {
+                    return new Token(TokenTypes.RESERVED, token.Value, token.Regex, token.WhitespaceBefore);
+                }
+            }
+
+            return token;
+        }
+
+        private bool IsTransactionBegin(Token next)
+        {
+            if (next == null)
+            {
+                return false;
+            }
+
+            var nextVal = next.Value.ToUpperInvariant();
+            if (nextVal == "TRAN" || nextVal == "TRANSACTION")
+            {
+                return true;
+            }
+
+            if (nextVal == "DISTRIBUTED")
+            {
+                var second = TokenLookAhead(2);
+                if (second != null)
+                {
+                    var secondVal = second.Value.ToUpperInvariant();
+                    if (secondVal == "TRAN" || secondVal == "TRANSACTION")
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- treat `BEGIN`/`END` as block delimiters in T-SQL
- test tokenizer and formatter for nested `BEGIN…END`
- document BEGIN/END block support

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c041e6e658832d9fcd4670e77465be