### PR TITLE
feat(tsql): format procedure definitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+## T-SQL Formatting
+- Add multi-word top-level keywords (e.g., `CREATE PROCEDURE`, `ALTER PROCEDURE`) to `s_reservedTopLevelWords` in `TSqlFormatter` to ensure stored procedure definitions are formatted as standalone statements.

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -146,5 +146,27 @@ namespace SQL.Formatter.Test
                         { "var name2", "'var value2'"},
                     }));
         }
+
+        [Fact]
+        public void FormatsCreateProcedureDefinition()
+        {
+            Assert.Equal(
+                "CREATE PROCEDURE\n"
+                + "  test AS\n"
+                + "SELECT\n"
+                + "  1;",
+                Formatter.Format("CREATE PROCEDURE test AS SELECT 1;"));
+        }
+
+        [Fact]
+        public void FormatsAlterProcedureDefinition()
+        {
+            Assert.Equal(
+                "ALTER PROCEDURE\n"
+                + "  test AS\n"
+                + "SELECT\n"
+                + "  1;",
+                Formatter.Format("ALTER PROCEDURE test AS SELECT 1;"));
+        }
     }
 }

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -196,8 +196,11 @@ namespace SQL.Formatter.Language
             new List<string>{
                 "ADD",
                 "ALTER COLUMN",
+                // Recognize procedure definition clauses as independent statements
+                "ALTER PROCEDURE",
                 "ALTER TABLE",
                 "CASE",
+                "CREATE PROCEDURE",
                 "DELETE FROM",
                 "END",
                 "EXCEPT",


### PR DESCRIPTION
## Summary
- support ALTER/CREATE PROCEDURE as top-level statements in T-SQL formatter
- test formatting for procedure definitions
- document formatter guidance for T-SQL keywords

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c041ef1354832d8e8af78b50517426