### PR TITLE
feat: support custom query delimiters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 ## Core
 - Tokenizer accepts `FormatConfig.QuerySeparators` to emit `QUERY_SEPARATOR` tokens (e.g., `GO`).
+- `FormatConfig` exposes `WithQuerySeparators` and `PlusQuerySeparators` helpers for immutably setting query delimiters.
 
 ## Formatting
 - `FormatQuerySeparator` resets indentation and handles semicolons and custom query delimiters.
+
+## Dialects
+- `Dialect.TSql` uses `WithQuerySeparators` to insert `"GO"` when no query separators are supplied.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,4 @@
 - `FormatQuerySeparator` resets indentation and handles semicolons and custom query delimiters.
 
 ## Dialects
-- `Dialect.TSql` uses `WithQuerySeparators` to insert `"GO"` when no query separators are supplied.
+- `TSqlFormatter` injects `GO` alongside the default semicolon when no custom query separators are supplied.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+## Core
+- Tokenizer accepts `FormatConfig.QuerySeparators` to emit `QUERY_SEPARATOR` tokens (e.g., `GO`).
+
+## Formatting
+- `FormatQuerySeparator` resets indentation and handles semicolons and custom query delimiters.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SqlFormatter.Format("SELECT * FROM tbl",
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.
-    .QuerySeparators(new List<string>{"GO"}) // Use when SQL Server dialect is selected
+    .QuerySeparators(new List<string>{"GO", ";"}) // Defaults to ';'. Include 'GO' for SQL Server
     .Build());
 );
 ```
@@ -58,7 +58,7 @@ You can also modify an existing configuration immutably:
 
 ```c#
 var cfg = FormatConfig.Builder().Build();
-var cfgWithGo = cfg.WithQuerySeparators("GO");
+var cfgWithGo = cfg.WithQuerySeparators("GO"); // Replaces default ';'
 ```
 
 ## Dialect

--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@ SqlFormatter.Format("SELECT * FROM tbl",
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.
-    .QuerySeparators(new List<string>{"GO"}) // Defaults to ["GO"]
+    .QuerySeparators(new List<string>{"GO"}) // Use when SQL Server dialect is selected
     .Build());
 );
+```
+
+You can also modify an existing configuration immutably:
+
+```c#
+var cfg = FormatConfig.Builder().Build();
+var cfgWithGo = cfg.WithQuerySeparators("GO");
 ```
 
 ## Dialect

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This repository contains the C# port of the popular [Java SQL formatter](https:/
 This does not support:
 
 - Stored procedures.
-- Changing of the delimiter type to something else than ;.
 
 # Usage
 
@@ -50,6 +49,7 @@ SqlFormatter.Format("SELECT * FROM tbl",
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.
+    .QuerySeparators(new List<string>{"GO"}) // Defaults to ["GO"]
     .Build());
 );
 ```

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -7,6 +7,17 @@ namespace SQL.Formatter.Test
     public class FormatConfigTest
     {
         [Fact]
+        public void WithQuerySeparatorsReplacesDefaultSemicolon()
+        {
+            var cfg = FormatConfig.Builder()
+                .Build()
+                .WithQuerySeparators("GO");
+
+            Assert.Single(cfg.QuerySeparators);
+            Assert.Equal("GO", cfg.QuerySeparators[0]);
+        }
+
+        [Fact]
         public void WithQuerySeparatorsReplacesExisting()
         {
             var cfg = FormatConfig.Builder()

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using SQL.Formatter.Core;
+using Xunit;
+
+namespace SQL.Formatter.Test
+{
+    public class FormatConfigTest
+    {
+        [Fact]
+        public void WithQuerySeparatorsReplacesExisting()
+        {
+            var cfg = FormatConfig.Builder()
+                .QuerySeparators("GO")
+                .Build()
+                .WithQuerySeparators("END");
+
+            Assert.Single(cfg.QuerySeparators);
+            Assert.Equal("END", cfg.QuerySeparators[0]);
+        }
+
+        [Fact]
+        public void PlusQuerySeparatorsAppendsSeparators()
+        {
+            var cfg = FormatConfig.Builder()
+                .QuerySeparators("GO")
+                .Build()
+                .PlusQuerySeparators("END", "STOP");
+
+            Assert.Equal(new List<string> { "GO", "END", "STOP" }, cfg.QuerySeparators);
+        }
+    }
+}

--- a/SQL.Formatter.Test/StandardSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/StandardSqlFormatterTest.cs
@@ -147,5 +147,16 @@ namespace SQL.Formatter.Test
                 _formatter.Format(
                     "merge into DW_STG_USER.ACCOUNT_DIM target using ( select COMMON_NAME m_commonName, ORIGIN m_origin, USAGE_TYPE m_usageType, CATEGORY m_category from MY_TABLE where USAGE_TYPE = :value ) source on source.m_usageType = target.USAGE_TYPE when matched then update set target.COMMON_NAME = source.m_commonName, target.ORIGIN = source.m_origin, target.USAGE_TYPE = source.m_usageType, target.CATEGORY = source.m_category where ((source.m_commonName <> target.COMMON_NAME)or(source.m_origin <> target.ORIGIN)or(source.m_usageType <> target.USAGE_TYPE)or(source.m_category <> target.CATEGORY)) when not matched then insert ( target.COMMON_NAME, target.ORIGIN, target.USAGE_TYPE, target.CATEGORY) values (source.m_commonName, source.m_origin, source.m_usageType, source.m_category)"));
         }
+
+        [Fact]
+        public void DoesNotTreatGoAsDelimiter()
+        {
+            Assert.Equal(
+                "select\n" +
+                "  go\n" +
+                "from\n" +
+                "  items",
+                _formatter.Format("select go from items"));
+        }
     }
 }

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -158,5 +158,131 @@ namespace SQL.Formatter.Test
                             "  2";
             Assert.Equal(expected, Formatter.Format(sql));
         }
+
+        [Fact]
+        public void FormatsMultipleQueriesSeparatedBySemicolons()
+        {
+            var sql = "SELECT 1;SELECT 2;SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1;\n" +
+                "SELECT\n" +
+                "  2;\n" +
+                "SELECT\n" +
+                "  3";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void PlacesGoOnItsOwnLineEvenWithoutLineBreaks()
+        {
+            var sql = "SELECT 1 GO SELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void HandlesLowercaseAndMixedCaseGo()
+        {
+            var sql = "SELECT 1\n" +
+                      "go\n" +
+                      "SELECT 2\n" +
+                      "Go\n" +
+                      "SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "go\n" +
+                "SELECT\n" +
+                "  2\n" +
+                "Go\n" +
+                "SELECT\n" +
+                "  3";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void DoesNotTreatGoPrefixAsSeparator()
+        {
+            var sql = "SELECT 1\nGONEXT\nSELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1 GONEXT\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void IgnoresGoAndSemicolonInsideStringsAndComments()
+        {
+            var sql = "SELECT 'GO' AS label; -- GO should not split\nSELECT 1";
+            var expected =
+                "SELECT\n" +
+                "  'GO' AS label;\n" +
+                "-- GO should not split\n" +
+                "SELECT\n" +
+                "  1";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void SemicolonAtEndOfInputProducesNoTrailingNewline()
+        {
+            var sql = "SELECT 1;";
+            var expected =
+                "SELECT\n" +
+                "  1;";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void GoAtEndOfInputProducesNoTrailingNewline()
+        {
+            var sql = "SELECT 1\nGO";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void ConsecutiveGoSeparatorsArePreserved()
+        {
+            var sql = "SELECT 1\nGO\nGO\nSELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO\n" +
+                "GO\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void CustomSeparatorsDisableDefaultGoAndSemicolon()
+        {
+            var cfg = SQL.Formatter.Core.FormatConfig.Builder()
+                .QuerySeparators("END")
+                .Build();
+
+            var sql = "SELECT 1 END SELECT 2; GO SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "END\n" +
+                "SELECT\n" +
+                "  2 ; GO\nSELECT\n" +
+                "  3";
+
+            Assert.Equal(expected, Formatter.Format(sql, cfg));
+        }
     }
 }

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -146,5 +146,17 @@ namespace SQL.Formatter.Test
                         { "var name2", "'var value2'"},
                     }));
         }
+
+        [Fact]
+        public void FormatsQueriesSeparatedByGo()
+        {
+            var sql = "SELECT 1\nGO\nSELECT 2";
+            var expected = "SELECT\n" +
+                            "  1\n" +
+                            "GO\n" +
+                            "SELECT\n" +
+                            "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
     }
 }

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -250,23 +250,33 @@ namespace SQL.Formatter.Core
 
         /// <summary>
         /// Resets indentation and appends the configured spacing after a statement delimiter
-        /// such as ';' or custom separators like 'GO'.
+        /// such as ';' or custom separators like 'GO'. Inline separators (e.g., ';') are kept on
+        /// the same line; non-inline separators (e.g., 'GO') are placed on their own line.
         /// </summary>
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var before = token.Type == TokenTypes.QUERY_SEPARATOR
-               ? AddNewline(query)
-               : query.TrimEnd();
+
+            var isInline = IsInlineSeparator(token.Value);
+            var before = isInline ? query.TrimEnd() : AddNewline(query);
+
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (token.Type == TokenTypes.QUERY_SEPARATOR)
+            if (!isInline)
             {
+                // Add an extra newline after non-inline separators (like GO) to visually separate batches.
                 lines += 1;
             }
 
-            return before
-                + Show(token)
-                + Utils.Repeat("\n", lines);
+            return before + Show(token) + Utils.Repeat("\n", lines);
+        }
+
+        /// <summary>
+        /// Returns true if the query separator should be rendered inline with the preceding statement.
+        /// Defaults to ';'. Dialects may override to customize behavior.
+        /// </summary>
+        protected virtual bool IsInlineSeparator(string separator)
+        {
+            return separator == ";";
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -30,7 +30,7 @@ namespace SQL.Formatter.Core
 
         public Tokenizer Tokenizer()
         {
-            return new Tokenizer(DoDialectConfig());
+            return new Tokenizer(DoDialectConfig(), _cfg.QuerySeparators);
         }
 
         protected virtual Token TokenOverride(Token token)
@@ -109,7 +109,7 @@ namespace SQL.Formatter.Core
                 {
                     formattedQuery = FormatWithoutSpaces(token, formattedQuery);
                 }
-                else if (token.Value.Equals(";"))
+                else if (token.Type == TokenTypes.QUERY_SEPARATOR || token.Value.Equals(";"))
                 {
                     formattedQuery = FormatQuerySeparator(token, formattedQuery);
                 }
@@ -248,12 +248,25 @@ namespace SQL.Formatter.Core
             return query + Show(token) + " ";
         }
 
+        /// <summary>
+        /// Resets indentation and appends the configured spacing after a statement delimiter
+        /// such as ';' or custom separators like 'GO'.
+        /// </summary>
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            return query.TrimEnd()
+            var before = token.Type == TokenTypes.QUERY_SEPARATOR
+                ? AddNewline(query)
+                : query.TrimEnd();
+            var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
+            if (token.Type == TokenTypes.QUERY_SEPARATOR)
+            {
+                lines += 1;
+            }
+
+            return before
                 + Show(token)
-                + Utils.Repeat("\n", _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries);
+                + Utils.Repeat("\n", lines);
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -255,15 +255,18 @@ namespace SQL.Formatter.Core
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var isSemicolon = token.Value.Equals(";");
-            var before = isSemicolon ? query.TrimEnd() : AddNewline(query);
+            var before = token.Type == TokenTypes.QUERY_SEPARATOR
+               ? AddNewline(query)
+               : query.TrimEnd();
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (!isSemicolon)
+            if (token.Type == TokenTypes.QUERY_SEPARATOR)
             {
                 lines += 1;
             }
 
-            return before + Show(token) + Utils.Repeat("\n", lines);
+            return before
+                + Show(token)
+                + Utils.Repeat("\n", lines);
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -109,7 +109,7 @@ namespace SQL.Formatter.Core
                 {
                     formattedQuery = FormatWithoutSpaces(token, formattedQuery);
                 }
-                else if (token.Type == TokenTypes.QUERY_SEPARATOR || token.Value.Equals(";"))
+                else if (token.Type == TokenTypes.QUERY_SEPARATOR)
                 {
                     formattedQuery = FormatQuerySeparator(token, formattedQuery);
                 }
@@ -255,18 +255,15 @@ namespace SQL.Formatter.Core
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var before = token.Type == TokenTypes.QUERY_SEPARATOR
-                ? AddNewline(query)
-                : query.TrimEnd();
+            var isSemicolon = token.Value.Equals(";");
+            var before = isSemicolon ? query.TrimEnd() : AddNewline(query);
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (token.Type == TokenTypes.QUERY_SEPARATOR)
+            if (!isSemicolon)
             {
                 lines += 1;
             }
 
-            return before
-                + Show(token)
-                + Utils.Repeat("\n", lines);
+            return before + Show(token) + Utils.Repeat("\n", lines);
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -34,7 +34,46 @@ namespace SQL.Formatter.Core
             Uppercase = uppercase;
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
-            QuerySeparators = querySeparators ?? new List<string> { "GO" };
+            QuerySeparators = querySeparators ?? new List<string>();
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with the specified query separators.
+        /// </summary>
+        public FormatConfig WithQuerySeparators(List<string> querySeparators)
+        {
+            return new FormatConfig(
+                Indent,
+                MaxColumnLength,
+                Parameters,
+                Uppercase,
+                LinesBetweenQueries,
+                SkipWhitespaceNearBlockParentheses,
+                querySeparators);
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with the specified query separators.
+        /// </summary>
+        public FormatConfig WithQuerySeparators(params string[] querySeparators)
+        {
+            return WithQuerySeparators(querySeparators.ToList());
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with additional query separators appended.
+        /// </summary>
+        public FormatConfig PlusQuerySeparators(List<string> querySeparators)
+        {
+            return WithQuerySeparators(QuerySeparators.Concat(querySeparators).ToList());
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with additional query separators appended.
+        /// </summary>
+        public FormatConfig PlusQuerySeparators(params string[] querySeparators)
+        {
+            return PlusQuerySeparators(querySeparators.ToList());
         }
 
         public static FormatConfigBuilder Builder()
@@ -50,7 +89,7 @@ namespace SQL.Formatter.Core
             private bool _uppercase;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
-            private List<string> _querySeparators = new List<string> { "GO" };
+            private List<string> _querySeparators = new List<string>(); // Use when SQL Server dialect is selected
 
             public FormatConfigBuilder() { }
 
@@ -101,7 +140,7 @@ namespace SQL.Formatter.Core
             }
 
             /// <summary>
-            /// Sets tokens that separate individual queries, e.g. GO.
+            /// Sets tokens that separate individual queries, e.g. "GO" when SQL Server dialect is selected.
             /// </summary>
             public FormatConfigBuilder QuerySeparators(List<string> querySeparators)
             {
@@ -110,7 +149,7 @@ namespace SQL.Formatter.Core
             }
 
             /// <summary>
-            /// Sets tokens that separate individual queries, e.g. GO.
+            /// Sets tokens that separate individual queries, e.g. "GO" when SQL Server dialect is selected.
             /// </summary>
             public FormatConfigBuilder QuerySeparators(params string[] querySeparators)
             {

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -34,7 +34,7 @@ namespace SQL.Formatter.Core
             Uppercase = uppercase;
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
-            QuerySeparators = querySeparators ?? new List<string>();
+            QuerySeparators = querySeparators ?? new List<string> { ";" };
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace SQL.Formatter.Core
             private bool _uppercase;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
-            private List<string> _querySeparators = new List<string>(); // Use when SQL Server dialect is selected
+            private List<string> _querySeparators;
 
             public FormatConfigBuilder() { }
 

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace SQL.Formatter.Core
 {
+    /// <summary>
+    /// Configuration options that control formatting behaviour.
+    /// </summary>
     public class FormatConfig
     {
         public static readonly string DefaultIndent = "  ";
@@ -13,6 +17,7 @@ namespace SQL.Formatter.Core
         public readonly bool Uppercase;
         public readonly int LinesBetweenQueries;
         public readonly bool SkipWhitespaceNearBlockParentheses;
+        public readonly List<string> QuerySeparators;
 
         public FormatConfig(
             string indent,
@@ -20,7 +25,8 @@ namespace SQL.Formatter.Core
             Params parameters,
             bool uppercase,
             int linesBetweenQueries,
-            bool skipWhitespaceNearBlockParentheses)
+            bool skipWhitespaceNearBlockParentheses,
+            List<string> querySeparators)
         {
             Indent = indent;
             MaxColumnLength = maxColumnLength;
@@ -28,6 +34,7 @@ namespace SQL.Formatter.Core
             Uppercase = uppercase;
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
+            QuerySeparators = querySeparators ?? new List<string> { "GO" };
         }
 
         public static FormatConfigBuilder Builder()
@@ -43,10 +50,9 @@ namespace SQL.Formatter.Core
             private bool _uppercase;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
+            private List<string> _querySeparators = new List<string> { "GO" };
 
-            public FormatConfigBuilder()
-            {
-            }
+            public FormatConfigBuilder() { }
 
             public FormatConfigBuilder Indent(string indent)
             {
@@ -94,6 +100,24 @@ namespace SQL.Formatter.Core
                 return this;
             }
 
+            /// <summary>
+            /// Sets tokens that separate individual queries, e.g. GO.
+            /// </summary>
+            public FormatConfigBuilder QuerySeparators(List<string> querySeparators)
+            {
+                _querySeparators = querySeparators;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets tokens that separate individual queries, e.g. GO.
+            /// </summary>
+            public FormatConfigBuilder QuerySeparators(params string[] querySeparators)
+            {
+                _querySeparators = querySeparators.ToList();
+                return this;
+            }
+
             public FormatConfig Build()
             {
                 return new FormatConfig(
@@ -102,7 +126,8 @@ namespace SQL.Formatter.Core
                     _parameters,
                     _uppercase,
                     _linesBetweenQueries,
-                    _skipWhitespaceNearBlockParentheses);
+                    _skipWhitespaceNearBlockParentheses,
+                    _querySeparators);
             }
         }
     }

--- a/SQL.Formatter/Core/TokenTypes.cs
+++ b/SQL.Formatter/Core/TokenTypes.cs
@@ -15,5 +15,6 @@
         BLOCK_COMMENT,
         NUMBER,
         PLACEHOLDER,
+        QUERY_SEPARATOR,
     }
 }

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateQuerySeparatorRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateSeparatorRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateSeparatorRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -28,8 +28,15 @@ namespace SQL.Formatter.Core
         private readonly Regex _indexedPlaceholderPattern;
         private readonly Regex _indentNamedPlaceholderPattern;
         private readonly Regex _stringNamedPlaceholderPattern;
+        private readonly Regex _querySeparatorPattern;
 
-        public Tokenizer(DialectConfig cfg)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tokenizer"/> class using the provided dialect
+        /// configuration and custom query separators.
+        /// </summary>
+        /// <param name="cfg">Dialect specific configuration.</param>
+        /// <param name="querySeparators">Tokens that delimit separate SQL queries, such as GO.</param>
+        public Tokenizer(DialectConfig cfg, List<string> querySeparators)
         {
             _numberPattern = new Regex(
                 "^((-\\s*)?[0-9]+(\\.[0-9]+)?([eE]-?[0-9]+(\\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\\b");
@@ -74,6 +81,10 @@ namespace SQL.Formatter.Core
                 RegexUtil.CreatePlaceholderRegexPattern(
                     new JSLikeList<string>(cfg.NamedPlaceholderTypes),
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
+
+            _querySeparatorPattern = querySeparators != null && querySeparators.Any()
+                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
+                : null;
         }
 
         public JSLikeList<Token> Tokenize(string input)
@@ -113,6 +124,7 @@ namespace SQL.Formatter.Core
                 () => GetCloseParenToken(input),
                 () => GetPlaceholderToken(input),
                 () => GetNumberToken(input),
+                () => GetQuerySeparatorToken(input),
                 () => GetReservedWordToken(input, previousToken),
                 () => GetWordToken(input),
                 () => GetOperatorToken(input));
@@ -193,6 +205,14 @@ namespace SQL.Formatter.Core
         private Token GetNumberToken(string input)
         {
             return GetTokenOnFirstMatch(input, TokenTypes.NUMBER, _numberPattern);
+        }
+
+        /// <summary>
+        /// Attempts to tokenize configured query separator keywords such as GO.
+        /// </summary>
+        private Token GetQuerySeparatorToken(string input)
+        {
+            return GetTokenOnFirstMatch(input, TokenTypes.QUERY_SEPARATOR, _querySeparatorPattern);
         }
 
         private Token GetOperatorToken(string input)

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,6 +44,25 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
+        public static string CreateSeparatorRegex(JSLikeList<string> separators)
+        {
+            if (separators.IsEmpty())
+            {
+                return "^\b$";
+            }
+
+            var pattern = string.Join("|",
+                Utils.SortByLengthDesc(separators)
+                    .Map(s =>
+                    {
+                        var escaped = EscapeRegExp(s);
+                        return char.IsLetterOrDigit(s.Last()) ? escaped + "\\b" : escaped;
+                    })
+                    .ToList());
+
+            return "(?i)^(" + pattern + ")";
+        }
+
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,25 +44,6 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
-        public static string CreateSeparatorRegex(JSLikeList<string> separators)
-        {
-            if (separators.IsEmpty())
-            {
-                return "^\b$";
-            }
-
-            var pattern = string.Join("|",
-                Utils.SortByLengthDesc(separators)
-                    .Map(s =>
-                    {
-                        var escaped = EscapeRegExp(s);
-                        return char.IsLetterOrDigit(s.Last()) ? escaped + "\\b" : escaped;
-                    })
-                    .ToList());
-
-            return "(?i)^(" + pattern + ")";
-        }
-
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,6 +44,22 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
+        public static string CreateQuerySeparatorRegex(JSLikeList<string> separators)
+        {
+            if (separators.IsEmpty())
+            {
+                return "^\\b$";
+            }
+
+            var patterns = Utils.SortByLengthDesc(separators)
+                .Map(s => s.Any(char.IsLetterOrDigit)
+                    ? EscapeRegExp(s).Replace(" ", "\\s+") + "(?=$|\\s)"
+                    : EscapeRegExp(s))
+                .ToList();
+
+            return "(?i)^(" + string.Join("|", patterns) + ")";
+        }
+
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Language/Dialect.cs
+++ b/SQL.Formatter/Language/Dialect.cs
@@ -16,7 +16,13 @@ namespace SQL.Formatter.Language
         public static readonly Dialect Redshift = new Dialect(cfg => new RedshiftFormatter(cfg), "Redshift");
         public static readonly Dialect SparkSql = new Dialect(cfg => new SparkSqlFormatter(cfg), "SparkSql", "spark");
         public static readonly Dialect StandardSql = new Dialect(cfg => new StandardSqlFormatter(cfg), "StandardSql", "sql");
-        public static readonly Dialect TSql = new Dialect(cfg => new TSqlFormatter(cfg), "TSql");
+        public static readonly Dialect TSql = new Dialect(cfg =>
+        {
+            var cfgWithGo = cfg.QuerySeparators.Any()
+                ? cfg
+                : cfg.WithQuerySeparators("GO");
+            return new TSqlFormatter(cfgWithGo);
+        }, "TSql");
 
         public static IEnumerable<Dialect> Values
         {

--- a/SQL.Formatter/Language/Dialect.cs
+++ b/SQL.Formatter/Language/Dialect.cs
@@ -16,13 +16,7 @@ namespace SQL.Formatter.Language
         public static readonly Dialect Redshift = new Dialect(cfg => new RedshiftFormatter(cfg), "Redshift");
         public static readonly Dialect SparkSql = new Dialect(cfg => new SparkSqlFormatter(cfg), "SparkSql", "spark");
         public static readonly Dialect StandardSql = new Dialect(cfg => new StandardSqlFormatter(cfg), "StandardSql", "sql");
-        public static readonly Dialect TSql = new Dialect(cfg =>
-        {
-            var cfgWithGo = cfg.QuerySeparators.Any()
-                ? cfg
-                : cfg.WithQuerySeparators("GO");
-            return new TSqlFormatter(cfgWithGo);
-        }, "TSql");
+        public static readonly Dialect TSql = new Dialect(cfg => new TSqlFormatter(cfg), "TSql");
 
         public static IEnumerable<Dialect> Values
         {

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -262,7 +262,10 @@ namespace SQL.Formatter.Language
                 .Build();
         }
 
-        public TSqlFormatter(FormatConfig cfg) : base(cfg)
+        public TSqlFormatter(FormatConfig cfg)
+            : base(cfg.QuerySeparators.Count == 1 && cfg.QuerySeparators[0].Equals(";")
+                ? cfg.WithQuerySeparators("GO", ";")
+                : cfg)
         {
         }
     }


### PR DESCRIPTION
## Summary
- add QUERY_SEPARATOR token type and config to capture custom delimiters
- handle GO-like separators by resetting indentation and spacing
- document query separator option and demonstrate GO formatting

## Testing
- `dotnet format --verify-no-changes`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c041f7276c832db9fc36a3ddfb1f25