### PR TITLE
fix: avoid treating BEGIN TRAN as block in T-SQL

### DIFF
--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -171,5 +171,23 @@ namespace SQL.Formatter.Test
 
             Assert.Equal(expected, Formatter.Format(sql));
         }
+
+        [Fact]
+        public void DoesNotTreatBeginTranAsBlock()
+        {
+            var sql = "BEGIN TRAN\nSELECT 1";
+            var expected = "BEGIN TRAN\nSELECT\n  1";
+
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void DoesNotTreatBeginDistributedTranAsBlock()
+        {
+            var sql = "BEGIN DISTRIBUTED TRAN\nSELECT 1";
+            var expected = "BEGIN DISTRIBUTED TRAN\nSELECT\n  1";
+
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
     }
 }

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SQL.Formatter.Core;
 
 namespace SQL.Formatter.Language
@@ -267,6 +268,49 @@ namespace SQL.Formatter.Language
 
         public TSqlFormatter(FormatConfig cfg) : base(cfg)
         {
+        }
+
+        protected override Token TokenOverride(Token token)
+        {
+            if (token.Type == TokenTypes.OPEN_PAREN && token.Value.Equals("BEGIN", StringComparison.OrdinalIgnoreCase))
+            {
+                var next = TokenLookAhead();
+                if (IsTransactionBegin(next))
+                {
+                    return new Token(TokenTypes.RESERVED, token.Value, token.Regex, token.WhitespaceBefore);
+                }
+            }
+
+            return token;
+        }
+
+        private bool IsTransactionBegin(Token next)
+        {
+            if (next == null)
+            {
+                return false;
+            }
+
+            var nextVal = next.Value.ToUpperInvariant();
+            if (nextVal == "TRAN" || nextVal == "TRANSACTION")
+            {
+                return true;
+            }
+
+            if (nextVal == "DISTRIBUTED")
+            {
+                var second = TokenLookAhead(2);
+                if (second != null)
+                {
+                    var secondVal = second.Value.ToUpperInvariant();
+                    if (secondVal == "TRAN" || secondVal == "TRANSACTION")
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- treat transaction BEGIN tokens as reserved so T-SQL formatter doesn't increase indentation
- test formatter for BEGIN TRAN and BEGIN DISTRIBUTED TRAN blocks

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c09dfc1210832d96ececbf3ce54c42