### PR TITLE
feat: support BEGIN…END blocks in T-SQL

### DIFF
--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -188,7 +188,9 @@ namespace SQL.Formatter.Test
             var expected = "BEGIN DISTRIBUTED TRAN\nSELECT\n  1";
 
             Assert.Equal(expected, Formatter.Format(sql));
-          
+
+        }
+
         [Fact]
         public void FormatsCreateProcedureDefinition()
         {


### PR DESCRIPTION
## Summary
- fix missing closing brace in transaction regression test

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a59742c4832dbbd56b92128134e4