### PR TITLE
feat: support custom query delimiters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 ## Core
 - Tokenizer accepts `FormatConfig.QuerySeparators` to emit `QUERY_SEPARATOR` tokens (e.g., `GO`).
+- `FormatConfig` exposes `WithQuerySeparators` and `PlusQuerySeparators` helpers for immutably setting query delimiters.
 
 ## Formatting
 - `FormatQuerySeparator` resets indentation and handles semicolons and custom query delimiters.
+
+## Dialects
+- `Dialect.TSql` uses `WithQuerySeparators` to insert `"GO"` when no query separators are supplied.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@ SqlFormatter.Format("SELECT * FROM tbl",
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.
-    .QuerySeparators(new List<string>{"GO"}) // Defaults to ["GO"]
+    .QuerySeparators(new List<string>{"GO"}) // Use when SQL Server dialect is selected
     .Build());
 );
+```
+
+You can also modify an existing configuration immutably:
+
+```c#
+var cfg = FormatConfig.Builder().Build();
+var cfgWithGo = cfg.WithQuerySeparators("GO");
 ```
 
 ## Dialect

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using SQL.Formatter.Core;
+using Xunit;
+
+namespace SQL.Formatter.Test
+{
+    public class FormatConfigTest
+    {
+        [Fact]
+        public void WithQuerySeparatorsReplacesExisting()
+        {
+            var cfg = FormatConfig.Builder()
+                .QuerySeparators("GO")
+                .Build()
+                .WithQuerySeparators("END");
+
+            Assert.Single(cfg.QuerySeparators);
+            Assert.Equal("END", cfg.QuerySeparators[0]);
+        }
+
+        [Fact]
+        public void PlusQuerySeparatorsAppendsSeparators()
+        {
+            var cfg = FormatConfig.Builder()
+                .QuerySeparators("GO")
+                .Build()
+                .PlusQuerySeparators("END", "STOP");
+
+            Assert.Equal(new List<string> { "GO", "END", "STOP" }, cfg.QuerySeparators);
+        }
+    }
+}

--- a/SQL.Formatter.Test/StandardSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/StandardSqlFormatterTest.cs
@@ -147,5 +147,16 @@ namespace SQL.Formatter.Test
                 _formatter.Format(
                     "merge into DW_STG_USER.ACCOUNT_DIM target using ( select COMMON_NAME m_commonName, ORIGIN m_origin, USAGE_TYPE m_usageType, CATEGORY m_category from MY_TABLE where USAGE_TYPE = :value ) source on source.m_usageType = target.USAGE_TYPE when matched then update set target.COMMON_NAME = source.m_commonName, target.ORIGIN = source.m_origin, target.USAGE_TYPE = source.m_usageType, target.CATEGORY = source.m_category where ((source.m_commonName <> target.COMMON_NAME)or(source.m_origin <> target.ORIGIN)or(source.m_usageType <> target.USAGE_TYPE)or(source.m_category <> target.CATEGORY)) when not matched then insert ( target.COMMON_NAME, target.ORIGIN, target.USAGE_TYPE, target.CATEGORY) values (source.m_commonName, source.m_origin, source.m_usageType, source.m_category)"));
         }
+
+        [Fact]
+        public void DoesNotTreatGoAsDelimiter()
+        {
+            Assert.Equal(
+                "select\n" +
+                "  go\n" +
+                "from\n" +
+                "  items",
+                _formatter.Format("select go from items"));
+        }
     }
 }

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -34,7 +34,46 @@ namespace SQL.Formatter.Core
             Uppercase = uppercase;
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
-            QuerySeparators = querySeparators ?? new List<string> { "GO" };
+            QuerySeparators = querySeparators ?? new List<string>();
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with the specified query separators.
+        /// </summary>
+        public FormatConfig WithQuerySeparators(List<string> querySeparators)
+        {
+            return new FormatConfig(
+                Indent,
+                MaxColumnLength,
+                Parameters,
+                Uppercase,
+                LinesBetweenQueries,
+                SkipWhitespaceNearBlockParentheses,
+                querySeparators);
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with the specified query separators.
+        /// </summary>
+        public FormatConfig WithQuerySeparators(params string[] querySeparators)
+        {
+            return WithQuerySeparators(querySeparators.ToList());
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with additional query separators appended.
+        /// </summary>
+        public FormatConfig PlusQuerySeparators(List<string> querySeparators)
+        {
+            return WithQuerySeparators(QuerySeparators.Concat(querySeparators).ToList());
+        }
+
+        /// <summary>
+        /// Returns a copy of this configuration with additional query separators appended.
+        /// </summary>
+        public FormatConfig PlusQuerySeparators(params string[] querySeparators)
+        {
+            return PlusQuerySeparators(querySeparators.ToList());
         }
 
         public static FormatConfigBuilder Builder()
@@ -50,7 +89,7 @@ namespace SQL.Formatter.Core
             private bool _uppercase;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
-            private List<string> _querySeparators = new List<string> { "GO" };
+            private List<string> _querySeparators = new List<string>(); // Use when SQL Server dialect is selected
 
             public FormatConfigBuilder() { }
 
@@ -101,7 +140,7 @@ namespace SQL.Formatter.Core
             }
 
             /// <summary>
-            /// Sets tokens that separate individual queries, e.g. GO.
+            /// Sets tokens that separate individual queries, e.g. "GO" when SQL Server dialect is selected.
             /// </summary>
             public FormatConfigBuilder QuerySeparators(List<string> querySeparators)
             {
@@ -110,7 +149,7 @@ namespace SQL.Formatter.Core
             }
 
             /// <summary>
-            /// Sets tokens that separate individual queries, e.g. GO.
+            /// Sets tokens that separate individual queries, e.g. "GO" when SQL Server dialect is selected.
             /// </summary>
             public FormatConfigBuilder QuerySeparators(params string[] querySeparators)
             {

--- a/SQL.Formatter/Language/Dialect.cs
+++ b/SQL.Formatter/Language/Dialect.cs
@@ -16,7 +16,13 @@ namespace SQL.Formatter.Language
         public static readonly Dialect Redshift = new Dialect(cfg => new RedshiftFormatter(cfg), "Redshift");
         public static readonly Dialect SparkSql = new Dialect(cfg => new SparkSqlFormatter(cfg), "SparkSql", "spark");
         public static readonly Dialect StandardSql = new Dialect(cfg => new StandardSqlFormatter(cfg), "StandardSql", "sql");
-        public static readonly Dialect TSql = new Dialect(cfg => new TSqlFormatter(cfg), "TSql");
+        public static readonly Dialect TSql = new Dialect(cfg =>
+        {
+            var cfgWithGo = cfg.QuerySeparators.Any()
+                ? cfg
+                : cfg.WithQuerySeparators("GO");
+            return new TSqlFormatter(cfgWithGo);
+        }, "TSql");
 
         public static IEnumerable<Dialect> Values
         {


### PR DESCRIPTION
## Summary
- add WithQuerySeparators and PlusQuerySeparators helpers to FormatConfig
- use WithQuerySeparators in TSql dialect instead of rebuilding config
- document query separator helpers and add unit tests

## Testing
- `dotnet format SqlFormatter.sln --verify-no-changes --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c09e46bd50832d83be7b0ce29f5531