### PR TITLE
feat: make semicolon configurable query separator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,4 @@
 - `FormatQuerySeparator` resets indentation and handles semicolons and custom query delimiters.
 
 ## Dialects
-- `Dialect.TSql` uses `WithQuerySeparators` to insert `"GO"` when no query separators are supplied.
+- `TSqlFormatter` injects `GO` alongside the default semicolon when no custom query separators are supplied.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SqlFormatter.Format("SELECT * FROM tbl",
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.
-    .QuerySeparators(new List<string>{"GO"}) // Use when SQL Server dialect is selected
+    .QuerySeparators(new List<string>{"GO", ";"}) // Defaults to ';'. Include 'GO' for SQL Server
     .Build());
 );
 ```
@@ -58,7 +58,7 @@ You can also modify an existing configuration immutably:
 
 ```c#
 var cfg = FormatConfig.Builder().Build();
-var cfgWithGo = cfg.WithQuerySeparators("GO");
+var cfgWithGo = cfg.WithQuerySeparators("GO"); // Replaces default ';'
 ```
 
 ## Dialect

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -7,6 +7,17 @@ namespace SQL.Formatter.Test
     public class FormatConfigTest
     {
         [Fact]
+        public void WithQuerySeparatorsReplacesDefaultSemicolon()
+        {
+            var cfg = FormatConfig.Builder()
+                .Build()
+                .WithQuerySeparators("GO");
+
+            Assert.Single(cfg.QuerySeparators);
+            Assert.Equal("GO", cfg.QuerySeparators[0]);
+        }
+
+        [Fact]
         public void WithQuerySeparatorsReplacesExisting()
         {
             var cfg = FormatConfig.Builder()

--- a/SQL.Formatter.Test/TSqlFormatterTest.cs
+++ b/SQL.Formatter.Test/TSqlFormatterTest.cs
@@ -158,5 +158,131 @@ namespace SQL.Formatter.Test
                             "  2";
             Assert.Equal(expected, Formatter.Format(sql));
         }
+
+        [Fact]
+        public void FormatsMultipleQueriesSeparatedBySemicolons()
+        {
+            var sql = "SELECT 1;SELECT 2;SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1;\n" +
+                "SELECT\n" +
+                "  2;\n" +
+                "SELECT\n" +
+                "  3";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void PlacesGoOnItsOwnLineEvenWithoutLineBreaks()
+        {
+            var sql = "SELECT 1 GO SELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void HandlesLowercaseAndMixedCaseGo()
+        {
+            var sql = "SELECT 1\n" +
+                      "go\n" +
+                      "SELECT 2\n" +
+                      "Go\n" +
+                      "SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "go\n" +
+                "SELECT\n" +
+                "  2\n" +
+                "Go\n" +
+                "SELECT\n" +
+                "  3";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void DoesNotTreatGoPrefixAsSeparator()
+        {
+            var sql = "SELECT 1\nGONEXT\nSELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1 GONEXT\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void IgnoresGoAndSemicolonInsideStringsAndComments()
+        {
+            var sql = "SELECT 'GO' AS label; -- GO should not split\nSELECT 1";
+            var expected =
+                "SELECT\n" +
+                "  'GO' AS label;\n" +
+                "-- GO should not split\n" +
+                "SELECT\n" +
+                "  1";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void SemicolonAtEndOfInputProducesNoTrailingNewline()
+        {
+            var sql = "SELECT 1;";
+            var expected =
+                "SELECT\n" +
+                "  1;";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void GoAtEndOfInputProducesNoTrailingNewline()
+        {
+            var sql = "SELECT 1\nGO";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void ConsecutiveGoSeparatorsArePreserved()
+        {
+            var sql = "SELECT 1\nGO\nGO\nSELECT 2";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "GO\n" +
+                "GO\n" +
+                "SELECT\n" +
+                "  2";
+            Assert.Equal(expected, Formatter.Format(sql));
+        }
+
+        [Fact]
+        public void CustomSeparatorsDisableDefaultGoAndSemicolon()
+        {
+            var cfg = SQL.Formatter.Core.FormatConfig.Builder()
+                .QuerySeparators("END")
+                .Build();
+
+            var sql = "SELECT 1 END SELECT 2; GO SELECT 3";
+            var expected =
+                "SELECT\n" +
+                "  1\n" +
+                "END\n" +
+                "SELECT\n" +
+                "  2 ; GO\nSELECT\n" +
+                "  3";
+
+            Assert.Equal(expected, Formatter.Format(sql, cfg));
+        }
     }
 }

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -250,23 +250,33 @@ namespace SQL.Formatter.Core
 
         /// <summary>
         /// Resets indentation and appends the configured spacing after a statement delimiter
-        /// such as ';' or custom separators like 'GO'.
+        /// such as ';' or custom separators like 'GO'. Inline separators (e.g., ';') are kept on
+        /// the same line; non-inline separators (e.g., 'GO') are placed on their own line.
         /// </summary>
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var before = token.Type == TokenTypes.QUERY_SEPARATOR
-               ? AddNewline(query)
-               : query.TrimEnd();
+
+            var isInline = IsInlineSeparator(token.Value);
+            var before = isInline ? query.TrimEnd() : AddNewline(query);
+
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (token.Type == TokenTypes.QUERY_SEPARATOR)
+            if (!isInline)
             {
+                // Add an extra newline after non-inline separators (like GO) to visually separate batches.
                 lines += 1;
             }
 
-            return before
-                + Show(token)
-                + Utils.Repeat("\n", lines);
+            return before + Show(token) + Utils.Repeat("\n", lines);
+        }
+
+        /// <summary>
+        /// Returns true if the query separator should be rendered inline with the preceding statement.
+        /// Defaults to ';'. Dialects may override to customize behavior.
+        /// </summary>
+        protected virtual bool IsInlineSeparator(string separator)
+        {
+            return separator == ";";
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -255,15 +255,18 @@ namespace SQL.Formatter.Core
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var isSemicolon = token.Value.Equals(";");
-            var before = isSemicolon ? query.TrimEnd() : AddNewline(query);
+            var before = token.Type == TokenTypes.QUERY_SEPARATOR
+               ? AddNewline(query)
+               : query.TrimEnd();
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (!isSemicolon)
+            if (token.Type == TokenTypes.QUERY_SEPARATOR)
             {
                 lines += 1;
             }
 
-            return before + Show(token) + Utils.Repeat("\n", lines);
+            return before
+                + Show(token)
+                + Utils.Repeat("\n", lines);
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -109,7 +109,7 @@ namespace SQL.Formatter.Core
                 {
                     formattedQuery = FormatWithoutSpaces(token, formattedQuery);
                 }
-                else if (token.Type == TokenTypes.QUERY_SEPARATOR || token.Value.Equals(";"))
+                else if (token.Type == TokenTypes.QUERY_SEPARATOR)
                 {
                     formattedQuery = FormatQuerySeparator(token, formattedQuery);
                 }
@@ -255,18 +255,15 @@ namespace SQL.Formatter.Core
         protected virtual string FormatQuerySeparator(Token token, string query)
         {
             _indentation.ResetIndentation();
-            var before = token.Type == TokenTypes.QUERY_SEPARATOR
-                ? AddNewline(query)
-                : query.TrimEnd();
+            var isSemicolon = token.Value.Equals(";");
+            var before = isSemicolon ? query.TrimEnd() : AddNewline(query);
             var lines = _cfg.LinesBetweenQueries == default ? 1 : _cfg.LinesBetweenQueries;
-            if (token.Type == TokenTypes.QUERY_SEPARATOR)
+            if (!isSemicolon)
             {
                 lines += 1;
             }
 
-            return before
-                + Show(token)
-                + Utils.Repeat("\n", lines);
+            return before + Show(token) + Utils.Repeat("\n", lines);
         }
 
         protected virtual string Show(Token token)

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -34,7 +34,7 @@ namespace SQL.Formatter.Core
             Uppercase = uppercase;
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
-            QuerySeparators = querySeparators ?? new List<string>();
+            QuerySeparators = querySeparators ?? new List<string> { ";" };
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace SQL.Formatter.Core
             private bool _uppercase;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
-            private List<string> _querySeparators = new List<string>(); // Use when SQL Server dialect is selected
+            private List<string> _querySeparators;
 
             public FormatConfigBuilder() { }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateQuerySeparatorRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateSeparatorRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Tokenizer.cs
+++ b/SQL.Formatter/Core/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace SQL.Formatter.Core
                     RegexUtil.CreateStringPattern(new JSLikeList<string>(cfg.StringTypes)));
 
             _querySeparatorPattern = querySeparators != null && querySeparators.Any()
-                ? new Regex(RegexUtil.CreateReservedWordRegex(new JSLikeList<string>(querySeparators)))
+                ? new Regex(RegexUtil.CreateSeparatorRegex(new JSLikeList<string>(querySeparators)))
                 : null;
         }
 

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,6 +44,25 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
+        public static string CreateSeparatorRegex(JSLikeList<string> separators)
+        {
+            if (separators.IsEmpty())
+            {
+                return "^\b$";
+            }
+
+            var pattern = string.Join("|",
+                Utils.SortByLengthDesc(separators)
+                    .Map(s =>
+                    {
+                        var escaped = EscapeRegExp(s);
+                        return char.IsLetterOrDigit(s.Last()) ? escaped + "\\b" : escaped;
+                    })
+                    .ToList());
+
+            return "(?i)^(" + pattern + ")";
+        }
+
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,25 +44,6 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
-        public static string CreateSeparatorRegex(JSLikeList<string> separators)
-        {
-            if (separators.IsEmpty())
-            {
-                return "^\b$";
-            }
-
-            var pattern = string.Join("|",
-                Utils.SortByLengthDesc(separators)
-                    .Map(s =>
-                    {
-                        var escaped = EscapeRegExp(s);
-                        return char.IsLetterOrDigit(s.Last()) ? escaped + "\\b" : escaped;
-                    })
-                    .ToList());
-
-            return "(?i)^(" + pattern + ")";
-        }
-
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Core/Util/RegexUtil.cs
+++ b/SQL.Formatter/Core/Util/RegexUtil.cs
@@ -44,6 +44,22 @@ namespace SQL.Formatter.Core.Util
             return "(?i)" + "^(" + reservedWordsPattern + ")\\b";
         }
 
+        public static string CreateQuerySeparatorRegex(JSLikeList<string> separators)
+        {
+            if (separators.IsEmpty())
+            {
+                return "^\\b$";
+            }
+
+            var patterns = Utils.SortByLengthDesc(separators)
+                .Map(s => s.Any(char.IsLetterOrDigit)
+                    ? EscapeRegExp(s).Replace(" ", "\\s+") + "(?=$|\\s)"
+                    : EscapeRegExp(s))
+                .ToList();
+
+            return "(?i)^(" + string.Join("|", patterns) + ")";
+        }
+
         public static string CreateWordRegex(JSLikeList<string> specialChars)
         {
             return "^([\\p{L}\\p{Nd}\\p{Mn}\\p{Pc}"

--- a/SQL.Formatter/Language/Dialect.cs
+++ b/SQL.Formatter/Language/Dialect.cs
@@ -16,13 +16,7 @@ namespace SQL.Formatter.Language
         public static readonly Dialect Redshift = new Dialect(cfg => new RedshiftFormatter(cfg), "Redshift");
         public static readonly Dialect SparkSql = new Dialect(cfg => new SparkSqlFormatter(cfg), "SparkSql", "spark");
         public static readonly Dialect StandardSql = new Dialect(cfg => new StandardSqlFormatter(cfg), "StandardSql", "sql");
-        public static readonly Dialect TSql = new Dialect(cfg =>
-        {
-            var cfgWithGo = cfg.QuerySeparators.Any()
-                ? cfg
-                : cfg.WithQuerySeparators("GO");
-            return new TSqlFormatter(cfgWithGo);
-        }, "TSql");
+        public static readonly Dialect TSql = new Dialect(cfg => new TSqlFormatter(cfg), "TSql");
 
         public static IEnumerable<Dialect> Values
         {

--- a/SQL.Formatter/Language/TSqlFormatter.cs
+++ b/SQL.Formatter/Language/TSqlFormatter.cs
@@ -262,7 +262,10 @@ namespace SQL.Formatter.Language
                 .Build();
         }
 
-        public TSqlFormatter(FormatConfig cfg) : base(cfg)
+        public TSqlFormatter(FormatConfig cfg)
+            : base(cfg.QuerySeparators.Count == 1 && cfg.QuerySeparators[0].Equals(";")
+                ? cfg.WithQuerySeparators("GO", ";")
+                : cfg)
         {
         }
     }


### PR DESCRIPTION
## Summary
- default query separator now includes ";" and can be replaced
- T-SQL dialect auto-injects both "GO" and ";" when none specified
- document default separator and update coverage for replacement

## Testing
- `dotnet format SqlFormatter.sln --verify-no-changes --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c195bb454c832da679e054eb2f5cb7